### PR TITLE
fix: 修复横屏虚拟键盘布局问题

### DIFF
--- a/app/src/main/java/moe/fuqiuluo/mamu/widget/BuiltinKeyboard.kt
+++ b/app/src/main/java/moe/fuqiuluo/mamu/widget/BuiltinKeyboard.kt
@@ -149,7 +149,7 @@ class BuiltinKeyboard @JvmOverloads constructor(
             R.id.key_5 to "5", R.id.key_6 to "6", R.id.key_7 to "7", R.id.key_8 to "8",
             R.id.key_9 to "9", R.id.key_0 to "0",
             R.id.key_a to "A", R.id.key_b to "B", R.id.key_c to "C", R.id.key_d to "D",
-            R.id.key_e to "E", R.id.key_f to "F", R.id.key_g to "G",
+            R.id.key_e to "E", R.id.key_f to "F",
             R.id.key_h to "h", R.id.key_q to "Q", R.id.key_r to "r", R.id.key_w to "W", R.id.key_x to "X",
             R.id.key_colon to ":", R.id.key_semicolon to ";", R.id.key_tilde to "~",
             R.id.key_dot to ".", R.id.key_minus to "-", R.id.key_comma to ",",

--- a/app/src/main/res/layout/keyboard_landscape_expanded.xml
+++ b/app/src/main/res/layout/keyboard_landscape_expanded.xml
@@ -54,6 +54,11 @@
         android:weightSum="7">
 
         <Button
+            android:id="@+id/key_d"
+            style="@style/KeyboardButton"
+            android:text="D" />
+
+        <Button
             android:id="@+id/key_e"
             style="@style/KeyboardButton"
             android:text="E" />
@@ -62,11 +67,6 @@
             android:id="@+id/key_f"
             style="@style/KeyboardButton"
             android:text="F" />
-
-        <Button
-            android:id="@+id/key_g"
-            style="@style/KeyboardButton"
-            android:text="G" />
 
         <Button
             android:id="@+id/key_4"

--- a/app/src/main/res/layout/keyboard_landscape_function.xml
+++ b/app/src/main/res/layout/keyboard_landscape_function.xml
@@ -216,11 +216,10 @@
             android:src="@drawable/arrow_right_alt_24px" />
 
         <ImageButton
-            android:id="@+id/key_disabled"
+            android:id="@+id/key_collapse"
             style="@style/KeyboardIconButton"
-            android:contentDescription="禁用"
-            android:enabled="false"
-            android:src="@drawable/icon_close_24px" />
+            android:contentDescription="折叠"
+            android:src="@drawable/unfold_less_24px" />
     </LinearLayout>
 
 </LinearLayout>

--- a/app/src/main/res/layout/keyboard_portrait_function.xml
+++ b/app/src/main/res/layout/keyboard_portrait_function.xml
@@ -216,11 +216,10 @@
             android:src="@drawable/history_24px" />
 
         <ImageButton
-            android:id="@+id/key_disabled"
+            android:id="@+id/key_collapse"
             style="@style/KeyboardIconButton"
-            android:contentDescription="禁用"
-            android:enabled="false"
-            android:src="@drawable/icon_close_24px" />
+            android:contentDescription="折叠"
+            android:src="@drawable/unfold_less_24px" />
     </LinearLayout>
 
 </LinearLayout>


### PR DESCRIPTION
- 添加横屏展开键盘缺失的D按钮
- 移除未使用的G按钮
- 统一横屏展开键盘每行7个按钮布局
- 将功能键盘的禁用按钮改为折叠按钮