### PR TITLE
fix: 修复横屏badge显示、内存浏览数据展示和搜索列表浮点数格式化问题

### DIFF
--- a/app/src/main/java/moe/fuqiuluo/mamu/floating/adapter/SearchResultAdapter.kt
+++ b/app/src/main/java/moe/fuqiuluo/mamu/floating/adapter/SearchResultAdapter.kt
@@ -322,6 +322,30 @@ class SearchResultAdapter(
 
     companion object {
         private const val PAYLOAD_SELECTION_CHANGED = "selection_changed"
+        
+        /**
+         * 根据数据类型格式化显示值
+         * 对于浮点类型，确保显示为浮点数格式（如 1 -> 1.0）
+         */
+        private fun formatValueByType(value: String, type: DisplayValueType): String {
+            return try {
+                when (type) {
+                    DisplayValueType.FLOAT -> {
+                        // 直接解析为浮点数并格式化显示
+                        val floatValue = value.toFloatOrNull() ?: return value
+                        "%.6g".format(floatValue)
+                    }
+                    DisplayValueType.DOUBLE -> {
+                        // 直接解析为双精度浮点数并格式化显示
+                        val doubleValue = value.toDoubleOrNull() ?: return value
+                        "%.10g".format(doubleValue)
+                    }
+                    else -> value
+                }
+            } catch (e: Exception) {
+                value
+            }
+        }
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
@@ -367,8 +391,9 @@ class SearchResultAdapter(
                         // 地址
                         addressText.text = item.address.toString(16).uppercase()
 
-                        // 当前值
-                        valueText.text = item.value
+                        // 当前值 - 根据数据类型格式化显示
+                        val valueType = item.displayValueType ?: DisplayValueType.DWORD
+                        valueText.text = formatValueByType(item.value, valueType)
 
                         // 备份值（旧值）
                         val backup = MemoryBackupManager.getBackup(item.address)
@@ -383,7 +408,6 @@ class SearchResultAdapter(
                         pointerChainText.visibility = View.GONE
 
                         // 类型简称和颜色
-                        val valueType = item.displayValueType ?: DisplayValueType.DWORD
                         typeText.apply {
                             text = valueType.code
                             setTextColor(valueType.textColor)
@@ -403,8 +427,9 @@ class SearchResultAdapter(
                         // 地址
                         addressText.text = item.address.toString(16).uppercase()
 
-                        // 当前值
-                        valueText.text = item.value
+                        // 当前值 - 根据数据类型格式化显示
+                        val valueType = item.displayValueType ?: DisplayValueType.DWORD
+                        valueText.text = formatValueByType(item.value, valueType)
 
                         // 备份值（旧值）
                         val backup = MemoryBackupManager.getBackup(item.address)
@@ -419,7 +444,6 @@ class SearchResultAdapter(
                         pointerChainText.visibility = View.GONE
 
                         // 类型简称和颜色
-                        val valueType = item.displayValueType ?: DisplayValueType.DWORD
                         typeText.apply {
                             text = valueType.code
                             setTextColor(valueType.textColor)

--- a/app/src/main/java/moe/fuqiuluo/mamu/service/FloatingWindowService.kt
+++ b/app/src/main/java/moe/fuqiuluo/mamu/service/FloatingWindowService.kt
@@ -947,34 +947,50 @@ class FloatingWindowService : Service(), ProcessDeathMonitor.Callback {
      */
     @SuppressLint("SetTextI18n")
     private fun updateTabBadge(tabIndex: Int, count: Int, total: Int?) {
-        val tab = fullscreenBinding.tabLayout.getTabAt(tabIndex) ?: return
-
+        // 更新顶部 TabLayout 的 Badge（竖屏模式）
+        val tab = fullscreenBinding.tabLayout.getTabAt(tabIndex)
+        // 更新侧边栏 NavigationRail 的 Badge（横屏模式）
+        val menuItemId = getNavigationItemIdByIndex(tabIndex)
+        
         if (count <= 0 && (total == null || total <= 0)) {
             // 清除 Badge
-            tab.removeBadge()
+            tab?.removeBadge()
+            fullscreenBinding.sidebarNavigationRail.removeBadge(menuItemId)
         } else {
-            // 创建或更新 Badge
-            val badge = tab.orCreateBadge
-            badge.backgroundColor = getColor(R.color.floating_primary)
-            badge.badgeTextColor = getColor(android.R.color.white)
-            badge.maxCharacterCount = 6  // 允许显示更多字符
-
-            if (total != null && total > 0) {
-                // 显示 count/total 格式
-                badge.number = count
-                badge.clearNumber()
-                // 使用自定义文本显示 count/total
-                if (count > 9999) {
-                    badge.text = "9999+"
+            // 计算显示文本
+            val badgeText = if (count > 9999) "9999+" else "$count"
+            
+            // 更新 TabLayout Badge
+            tab?.let {
+                val badge = it.orCreateBadge
+                badge.backgroundColor = getColor(R.color.floating_primary)
+                badge.badgeTextColor = getColor(android.R.color.white)
+                badge.maxCharacterCount = 6
+                if (total != null && total > 0) {
+                    badge.clearNumber()
+                    badge.text = badgeText
                 } else {
-                    badge.text = "$count"
+                    if (count > 9999) {
+                        badge.text = badgeText
+                    } else {
+                        badge.number = count
+                    }
                 }
+            }
+            
+            // 更新 NavigationRail Badge
+            val railBadge = fullscreenBinding.sidebarNavigationRail.getOrCreateBadge(menuItemId)
+            railBadge.backgroundColor = getColor(R.color.floating_primary)
+            railBadge.badgeTextColor = getColor(android.R.color.white)
+            railBadge.maxCharacterCount = 6
+            if (total != null && total > 0) {
+                railBadge.clearNumber()
+                railBadge.text = badgeText
             } else {
-                // 只显示 count
                 if (count > 9999) {
-                    badge.text = "9999+"
+                    railBadge.text = badgeText
                 } else {
-                    badge.number = count
+                    railBadge.number = count
                 }
             }
         }


### PR DESCRIPTION
## 修复横屏Badge显示、内存浏览数据展示和搜索列表浮点数格式化问题

### 问题描述

1. **横屏模式下 Tab Badge 不显示**：在横屏状态下，搜索和保存地址的数量 badge 不会显示在侧边栏 NavigationRail 上
2. **内存浏览列表数据展示异常**：
   - 只有默认的 DWORD 类型显示正常，其他类型（如 QWORD、DOUBLE）显示不正确
   - 页面边界处的数据显示为 "?h; ?; ?D; ?F; ?E; ?Q"
3. **搜索列表浮点数显示错误**：Float 类型的值 "1" 显示为整数而非 "1.0"

### 修复内容

#### 1. FloatingWindowService - 横屏 Badge 显示
- `updateTabBadge` 方法现在同时更新顶部 `TabLayout`（竖屏）和侧边栏 `NavigationRail`（横屏）的 badge
- 使用 `getNavigationItemIdByIndex` 获取对应的菜单项 ID

#### 2. InfiniteMemoryAdapter - 内存浏览数据展示
- **Buffer 大小修复**：使用 `hexByteSize`（最大字节数）替代 `alignment`（最小字节数）创建 ByteBuffer，确保有足够空间读取所有数据格式
- **跨页边界读取**：当数据跨越页面边界时，从当前页和下一页合并数据
- **浮点数格式化**：Float/Double 使用 `%.6g`/`%.10g` 格式，自动选择普通或科学计数法显示

#### 3. SearchResultAdapter - 搜索列表浮点数格式化
- 新增 `formatValueByType` 方法，根据数据类型格式化显示值
- Float 类型的 "1" 正确显示为 "1.00000"
- Double 类型同样进行格式化处理
