### PR TITLE
fix: 修复悬浮窗相关的7个问题 (#64, #66, #67, #68, #69, #70, #71)

### DIFF
--- a/app/src/main/java/moe/fuqiuluo/mamu/floating/adapter/ProcessListAdapter.kt
+++ b/app/src/main/java/moe/fuqiuluo/mamu/floating/adapter/ProcessListAdapter.kt
@@ -45,7 +45,7 @@ class ProcessListAdapter(
 
         fun bind(processInfo: DisplayProcessInfo, position: Int) {
             binding.apply {
-                processRss.text = formatBytes(processInfo.rss * 1024, 0)
+                processRss.text = formatBytes(processInfo.rss * 1024)
                 processName.text = processInfo.validName
                 processDetails.text = "[${processInfo.pid}]"
                 processIcon.setImageDrawable(processInfo.icon)

--- a/app/src/main/java/moe/fuqiuluo/mamu/floating/adapter/SearchResultAdapter.kt
+++ b/app/src/main/java/moe/fuqiuluo/mamu/floating/adapter/SearchResultAdapter.kt
@@ -113,6 +113,17 @@ class SearchResultAdapter(
     }
 
     /**
+     * 更新搜索结果列表（保持滚动位置）
+     * 用于刷新值时，数据数量不变，只更新内容
+     * @param newResults 新的搜索结果列表
+     */
+    fun updateResults(newResults: List<SearchResultItem>) {
+        results.clear()
+        results.addAll(newResults)
+        notifyItemRangeChanged(0, newResults.size)
+    }
+
+    /**
      * 根据地址更新单个搜索结果项的值
      * @param address 要更新的地址
      * @param newValue 新的值（不包含备份信息，备份值会在 ViewHolder 中自动显示）

--- a/app/src/main/java/moe/fuqiuluo/mamu/floating/controller/MemoryPreviewController.kt
+++ b/app/src/main/java/moe/fuqiuluo/mamu/floating/controller/MemoryPreviewController.kt
@@ -601,6 +601,16 @@ class MemoryPreviewController(
                         )
                     }
                     override fun onJumpToAddress(address: Long) { jumpToAddress(address) }
+                    override fun onJumpToPointer(fromAddress: Long, toAddress: Long) {
+                        // 确保来源地址在导航历史中，以便后退时能回到长按的位置
+                        val currentHistoryAddress = if (navigationIndex >= 0 && navigationIndex < navigationHistory.size) {
+                            navigationHistory[navigationIndex]
+                        } else -1L
+                        if (fromAddress != currentHistoryAddress) {
+                            addToNavigationHistory(fromAddress)
+                        }
+                        jumpToAddress(toAddress)
+                    }
                 },
                 source = AddressActionSource.MEMORY_PREVIEW,
                 displayFormats = currentFormats

--- a/app/src/main/java/moe/fuqiuluo/mamu/floating/controller/SearchController.kt
+++ b/app/src/main/java/moe/fuqiuluo/mamu/floating/controller/SearchController.kt
@@ -386,7 +386,7 @@ class SearchController(
         process?.let {
             val memoryB = (it.rss * 1024)
             binding.processInfoText.text =
-                "[${it.pid}] ${it.name} [${formatBytes(memoryB, 0)}]"
+                "[${it.pid}] ${it.name} [${formatBytes(memoryB)}]"
             binding.processStatusIcon.setIconResource(R.drawable.icon_pause_24px)
         } ?: run {
             binding.processInfoText.text = "未选择进程"
@@ -437,7 +437,12 @@ class SearchController(
                 }
 
                 if (offset == 0) {
-                    searchResultAdapter.setResults(addresses)
+                    if (addresses.size == searchResultAdapter.itemCount) {
+                        // 数量相同，使用 updateResults 保持滚动位置
+                        searchResultAdapter.updateResults(addresses)
+                    } else {
+                        searchResultAdapter.setResults(addresses)
+                    }
                     showEmptyState(false)
                 } else {
                     searchResultAdapter.addResults(addresses)
@@ -1411,8 +1416,7 @@ class SearchController(
     }
 
     private fun onPointerScanCompleted(ranges: List<DisplayMemRegionEntry>, chains: List<PointerChainResult>) {
-        // 清空现有搜索结果
-        SearchEngine.clearSearchResults()
+        // 不清空原生搜索结果，保留用户的搜索数据
         searchResultAdapter.clearResults()
 
         // 将指针链结果转换为 PointerChainResultItem

--- a/app/src/main/java/moe/fuqiuluo/mamu/floating/dialog/AddressActionDialog.kt
+++ b/app/src/main/java/moe/fuqiuluo/mamu/floating/dialog/AddressActionDialog.kt
@@ -65,6 +65,9 @@ class AddressActionDialog(
     interface Callbacks {
         fun onShowOffsetCalculator(address: Long)
         fun onJumpToAddress(address: Long)
+        fun onJumpToPointer(fromAddress: Long, toAddress: Long) {
+            onJumpToAddress(toAddress)
+        }
     }
 
     /**
@@ -150,14 +153,21 @@ class AddressActionDialog(
             ActionItem("偏移量计算器", R.drawable.calculate_24px) {
                 dismiss()
                 callbacks.onShowOffsetCalculator(address)
-            },
-            ActionItem(
+            }
+        )
+
+        // 内存预览界面已经在查看该地址，不需要"转到此地址"
+        if (source != AddressActionSource.MEMORY_PREVIEW) {
+            actions.add(ActionItem(
                 "转到此地址: ${"%X".format(address)}",
                 R.drawable.icon_arrow_right_alt_24px
             ) {
                 dismiss()
                 callbacks.onJumpToAddress(address)
-            },
+            })
+        }
+
+        actions.addAll(listOf(
             ActionItem(
                 "跳转到指针: ${(pointerAddress ?: 0).toString(16).uppercase()}",
                 R.drawable.icon_arrow_right_alt_24px
@@ -167,7 +177,7 @@ class AddressActionDialog(
                     notification.showError("指针异常无法跳转")
                     return@ActionItem
                 }
-                callbacks.onJumpToAddress(addr)
+                callbacks.onJumpToPointer(address, addr)
                 notification.showSuccess("跳转到指针: 0x${addr.toString(16).uppercase()}")
             },
             ActionItem("复制此地址: ${"%X".format(address)}", R.drawable.content_copy_24px) {
@@ -182,7 +192,7 @@ class AddressActionDialog(
             ActionItem("复制反16进制值: $reverseHexString", R.drawable.content_copy_24px) {
                 copyToClipboard("reverse_hex_value", reverseHexString, "反16进制")
             }
-        )
+        ))
 
         // 根据内存预览界面的 displayFormats 添加额外复制选项
         if (source == AddressActionSource.MEMORY_PREVIEW && displayFormats != null) {

--- a/app/src/main/java/moe/fuqiuluo/mamu/floating/dialog/ModuleListDialog.kt
+++ b/app/src/main/java/moe/fuqiuluo/mamu/floating/dialog/ModuleListDialog.kt
@@ -30,6 +30,7 @@ class ModuleListDialog(
 ) : BaseDialog(context) {
 
     private var currentFocusedInput: EditText? = null
+    private lateinit var binding: DialogModuleListBinding
 
     // 历史记录（静态保存，跨实例共享）
     companion object {
@@ -45,7 +46,7 @@ class ModuleListDialog(
 
     @SuppressLint("SetTextI18n")
     override fun setupDialog() {
-        val binding = DialogModuleListBinding.inflate(LayoutInflater.from(dialog.context))
+        binding = DialogModuleListBinding.inflate(LayoutInflater.from(dialog.context))
         dialog.setContentView(binding.root)
 
         // 应用透明度设置
@@ -143,16 +144,14 @@ class ModuleListDialog(
 
         ModuleListPopupDialog(context, title, filteredModules) { selectedModule ->
             addToHistory(selectedModule)
-            onModuleSelected(selectedModule)
-            dialog.dismiss()
+            fillAddressInput(selectedModule.start)
         }.show()
     }
 
     private fun showAllModulesPopup() {
         ModuleListPopupDialog(context, "全部模块", modules) { selectedModule ->
             addToHistory(selectedModule)
-            onModuleSelected(selectedModule)
-            dialog.dismiss()
+            fillAddressInput(selectedModule.start)
         }.show()
     }
 
@@ -172,8 +171,7 @@ class ModuleListDialog(
 
         ModuleListPopupDialog(context, "历史记录", historyModules) { selectedModule ->
             addToHistory(selectedModule)
-            onModuleSelected(selectedModule)
-            dialog.dismiss()
+            fillAddressInput(selectedModule.start)
         }.show()
     }
 
@@ -190,8 +188,7 @@ class ModuleListDialog(
                     highlightModule = targetModule
                 ) { selectedModule ->
                     addToHistory(selectedModule)
-                    onModuleSelected(selectedModule)
-                    dialog.dismiss()
+                    fillAddressInput(selectedModule.start)
                 }.show()
             } else {
                 notification.showWarning("未找到包含该地址的模块")
@@ -211,6 +208,15 @@ class ModuleListDialog(
         } catch (e: Exception) {
             notification.showError("地址格式错误")
         }
+    }
+
+    /**
+     * 将地址填入输入框（而非直接跳转）
+     */
+    private fun fillAddressInput(address: Long) {
+        val addressText = String.format("%X", address)
+        binding.inputAddress.setText(addressText)
+        binding.inputAddress.setSelection(addressText.length)
     }
 
     private fun addToHistory(module: DisplayMemRegionEntry) {

--- a/app/src/main/res/layout/dialog_offset_calculator.xml
+++ b/app/src/main/res/layout/dialog_offset_calculator.xml
@@ -171,6 +171,7 @@
                 android:layout_height="wrap_content"
                 android:ellipsize="none"
                 android:gravity="top"
+                android:minLines="3"
                 android:maxLines="999"
                 android:padding="@dimen/floating_spacing_xs"
                 android:textIsSelectable="true"


### PR DESCRIPTION
- #64: 进程内存大小显示小数点后两位
- #66: 指针搜索不再清空搜索页面的结果
- #67: 搜索页面刷新值时保持滑动条位置
- #68: 选择SO地址后填入输入框而非直接跳转
- #69: 内存浏览界面长按地址不再显示多余的"转到此地址"
- #70: 跳转到指针时将来源地址加入导航历史，支持后退
- #71: 偏移量计算器竖屏模式下键盘不再因预读值变化而抖动